### PR TITLE
Ensure Controller's model is a PskBindableModel instance

### DIFF
--- a/base/controllers/Controller.js
+++ b/base/controllers/Controller.js
@@ -241,7 +241,12 @@ export default class Controller {
         chain = chain.slice(1);
         //has root chain '@'
         if (!chain) {
-          model = _model;
+            if(typeof _model.hasExpression === "function") {
+                // _model is already a root PskBindableModel
+                model = _model;
+            } else {
+                model = PskBindableModel.setModel(_model);
+            }
         } else {
           model = PskBindableModel.setModel(_model);
         }


### PR DESCRIPTION
In some cases the webc-container model binding breaks when setting the model as root.

e.g.
```
<webc-container shadow-root controller="components/AIRobot/AnchorCardController" data-view-model="@" >
```
with model
```
  this.model = {
            anchorCard: {
                header: "SuperRare",
                description: "A network governed by artists, collectors and curators.",
                memberCount: "199 members",
                cardImage: "./assets/icons/anchor-card-image.svg"

            }
};
```
breaks the binding.

The issue is that the model that is bounded inside the Controller is not an instance of **PskBindableModel**.
The fix checks if the given model is not a **PskBindableModel** (the function **hasExpression** must be present in order to be a **PskBindableModel**) and converts it accordingly. 

Taken from PskBindableModel project: 

> A valid psk_bindable_model must be a proxy with the following functions
>    * addExpression, evaluateExpression, hasExpression, onChangeExpressionChain, toObject
